### PR TITLE
Fix defect while projecting facts with predecessor arrays

### DIFF
--- a/src/hooks/useSpecification.ts
+++ b/src/hooks/useSpecification.ts
@@ -82,20 +82,26 @@ function removeObservables<TProjection>(projection: MakeObservable<TProjection>)
 
 function removeObservablesFromObject(projection: any): any {
   if (typeof projection === 'object') {
-    // If it is an object, remove all observables from its properties.
-    const result: any = {};
-    for (const key in projection) {
-      const value = projection[key];
-      // If the projection has a function called onAdded, then it is an observable collection.
-      // Replace it with an array.
-      if (typeof value === 'object' && typeof (value as any).onAdded === 'function') {
-        result[key] = [];
-      }
-      else {
-        result[key] = removeObservablesFromObject(value);
-      }
+    // If it is an array, remove all observables from its elements.
+    if (Array.isArray(projection)) {
+      return projection.map(removeObservablesFromObject);
     }
-    return result;
+    else {
+      // If it is an object, remove all observables from its properties.
+      const result: any = {};
+      for (const key in projection) {
+        const value = projection[key];
+        // If the projection has a function called onAdded, then it is an observable collection.
+        // Replace it with an array.
+        if (typeof value === 'object' && typeof (value as any).onAdded === 'function') {
+          result[key] = [];
+        }
+        else {
+          result[key] = removeObservablesFromObject(value);
+        }
+      }
+      return result;
+    }
   }
 
   // If it is not an object, it is a primitive value.

--- a/test/hooks/useSpecification.spec.ts
+++ b/test/hooks/useSpecification.spec.ts
@@ -1,11 +1,14 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { JinagaTest } from "jinaga";
 import { useSpecification } from "../../src";
-import { Item, ItemDescription, Root, model } from "../model";
+import { Item, ItemDeleted, ItemDescription, Root, model } from "../model";
 
 const itemsInRoot = model.given(Root).match((root, facts) =>
   facts.ofType(Item)
     .join(item => item.root, root)
+    .notExists(item => facts.ofType(ItemDeleted)
+      .join(deleted => deleted.item, item)
+    )
 );
 
 const descriptionsOfItem = model.given(Item).match((item, facts) =>
@@ -44,6 +47,47 @@ describe("useSpecification", () => {
     expect(roundTrip(result.current.data)).toEqual(roundTrip([item]));
   });
 
+  it("should add an item", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+
+    const item = await j.fact(new Item(root, new Date()));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([item]));
+  });
+
+  it("should remove an item", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+    const item = await j.fact(new Item(root, new Date()));
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+
+    await j.fact(new ItemDeleted(item));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toEqual([]);
+  });
+
   it("should return one description", async () => {
     const j = JinagaTest.create({});
     const root = await j.fact(new Root("root-identifier"));
@@ -57,6 +101,64 @@ describe("useSpecification", () => {
     expect(result.current.loading).toBeFalsy();
     expect(result.current.error).toBeNull();
     expect(roundTrip(result.current.data)).toEqual(roundTrip([description]));
+  });
+
+  it("should return a replaced description", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+    const item = await j.fact(new Item(root, new Date()));
+    const description = await j.fact(new ItemDescription(item, "description", []));
+    const replacement = await j.fact(new ItemDescription(item, "replacement", [description]));
+
+    const { result } = renderHook(() => useSpecification(j, descriptionsOfItem, item));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([replacement]));
+  });
+
+  it("should update on edit", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+    const item = await j.fact(new Item(root, new Date()));
+    const description = await j.fact(new ItemDescription(item, "description", []));
+
+    const { result } = renderHook(() => useSpecification(j, descriptionsOfItem, item));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([description]));
+
+    const replacement = await j.fact(new ItemDescription(item, "replacement", [description]));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([replacement]));
+  });
+
+  it("should return candidates for a concurrent edit", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+    const item = await j.fact(new Item(root, new Date()));
+    const description = await j.fact(new ItemDescription(item, "description", []));
+    const candidate1 = await j.fact(new ItemDescription(item, "candidate1", [description]));
+    const candidate2 = await j.fact(new ItemDescription(item, "candidate2", [description]));
+
+    const { result } = renderHook(() => useSpecification(j, descriptionsOfItem, item));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data?.length)).toBe(2);
+    expect(roundTrip(result.current.data)).toContainEqual(roundTrip(candidate1));
+    expect(roundTrip(result.current.data)).toContainEqual(roundTrip(candidate2));
   });
 });
 

--- a/test/hooks/useSpecification.spec.ts
+++ b/test/hooks/useSpecification.spec.ts
@@ -1,0 +1,42 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { JinagaTest } from "jinaga";
+import { useSpecification } from "../../src";
+import { Item, Root, model } from "../model";
+
+const itemsInRoot = model.given(Root).match((root, facts) =>
+  facts.ofType(Item)
+    .join(item => item.root, root)
+);
+
+describe("useSpecification", () => {
+  it("should return an empty list", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("should return one item", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+    const item = await j.fact(new Item(root, new Date()));
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([item]));
+  });
+});
+
+function roundTrip<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
- Set up tests for hooks
- Reproduce the error
- Don't map arrays to objects
- Round out the testing
