### PR TITLE
Update README with new full draft, Getting Started, and Example Project Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ npm install jinaga jinaga-react
 
 ## Getting Started
 
-Before you can use useSpecification, you need a Jinaga instance connected to a replicator.
+Before you can use useSpecification, you need a Jinaga client connected to a replicator.
 This allows your app to query facts locally and sync with a server.
 
 Here’s a simple setup:
 
-1. Create a Jinaga instance
+1. Create a Jinaga client
 
 ```javascript
-import { JinagaBrowser } from 'jinaga-browser';
+import { JinagaClient } from 'jinaga';
 
-export const j = new JinagaBrowser({
+export const j = JinagaClient.create({
   httpEndpoint: "https://your-replicator.example.com/"
 });
 ```
@@ -31,30 +31,34 @@ export const j = new JinagaBrowser({
 Example local replicator (development only):
 
 ```bash
-npx @jinaga/replicator
+docker pull jinaga/jinaga-replicator-no-security-policies
+docker run -d --name my-replicator -p8080:8080 jinaga/jinaga-replicator-no-security-policies
 ```
 
-This will start a replicator at http://localhost:8080/.
+This will start a replicator at http://localhost:8080/jinaga.
 
 2. Define your model
 
 Create a file like model.ts that defines your types and specifications.
 
 ```javascript
-import { predefine } from "jinaga";
+import { buildModel } from "jinaga";
 
 export class Post {
-  type = "Post" as const;
+  static Type = "Blog.Post" as const;
+  public type = Post.Type;
+
   constructor(
-    public messageId: string,
-    public content: string
-  ) {}
+    public createdAt: Date | string,
+    public site: Site
+  ) { }
 }
 
-export const postList = predefine(Post, j => j
-  .match()
-  .select()
-  .orderBy(p => p.messageId)
+export const model = buildModel(b => b
+  .type(Site)
+  .type(Post, m => m
+    .predecessor("site", Site)
+  )
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,179 +1,353 @@
 # Jinaga React
 
+Jinaga-React makes it easy to build reactive, offline-first applications in React using the Jinaga framework. It connects your domain model to your UI automatically, so you don’t have to write custom fetch logic or manage subscriptions yourself.
 
-
-Binding helpers for managing [React](https://reactjs.org) component state based on [Jinaga](https://jinaga.com) watches.
+## Installation
 
 ```bash
-npm install --save jinaga react react-dom jinaga-react
+npm install jinaga jinaga-react
 ```
 
-Full documentation can be found at [https://jinaga.com/documents/jinaga-react/](https://jinaga.com/documents/jinaga-react/).
+## Getting Started
 
-# Composition
+Before you can use useSpecification, you need a Jinaga instance connected to a replicator.
+This allows your app to query facts locally and sync with a server.
 
-User interfaces in React are composed from components.
-The Jinaga helper library for React provides ways to connect components to Jinaga template functions to create dynamic user interfaces.
-It breaks the problem into three layers:
+Here’s a simple setup:
 
-* Specifications
-* Mappings
-* Containers
-
-Mappings can further be used in collections to build structures of any depth.
-
-## Specifications
-
-Start by specifying a set of properties to be injected into a React component.
+1. Create a Jinaga instance
 
 ```javascript
-const messageSpec = specificationFor(Message, {
-    text: field(m => m.text),
-    sender: property(j.for(Message.sender).then(UserName.forUser), n => n.value, "<sender>")
+import { JinagaBrowser } from 'jinaga-browser';
+
+export const j = new JinagaBrowser({
+  httpEndpoint: "https://your-replicator.example.com/"
 });
 ```
 
-This specification defines two props.
-The `text` prop will be given the value of the text field of the `Message` fact.
-The `sender` prop will use the result of the template functions `Message.sender` and `UserName.forUser`.
-This sets up a query that will take the sender of the message, and then watch for their user name.
+- Replace the URL with your replicator’s address.
+- If you don’t have a replicator yet, you can run one locally using Jinaga Replicator.
 
-By default, the property will have the value `"<sender>"`, which is just there so that something gets displayed.
-That value will be used only if the sender has no name.
-In other words, if the `UserName.forUser` template matches no facts.
+Example local replicator (development only):
 
-You can get the results of a mapping with the hook `useResult`.
-Pass the Jinaga object, the starting fact, and the specification.
-Like all hooks, this can only be used within a render function -- typically in a function component.
+```bash
+npx @jinaga/replicator
+```
+
+This will start a replicator at http://localhost:8080/.
+
+2. Define your model
+
+Create a file like model.ts that defines your types and specifications.
 
 ```javascript
-const messageView = ({ message }) => {
-    const result = useResult(j, message, messageSpec);
+import { predefine } from "jinaga";
 
-    if (result === null) {
-        return <p>Loading</p>;
-    }
-    else {
-        const { text, sender } = message;
+export class Post {
+  type = "Post" as const;
+  constructor(
+    public messageId: string,
+    public content: string
+  ) {}
+}
 
-        return (
-            <>
-                <p className="message-text">{text}</p>
-                <p className="message-sender">{sender}</p>
-            </>
-        );
-    }
+export const postList = predefine(Post, j => j
+  .match()
+  .select()
+  .orderBy(p => p.messageId)
+);
+```
+
+- predefine lets you build queries declaratively.
+- Specifications describe what facts you want to display.
+
+3. Use useSpecification in your component
+
+Now you can bind the specification into your UI:
+
+```javascript
+import { useSpecification } from 'jinaga-react';
+import { j, postList } from './model';
+
+export function PostList() {
+  const { data: posts, loading } = useSpecification(j, postList, {});
+
+  if (posts === null) {
+    return null;
+  }
+
+  if (loading) {
+    return <div>Loading posts...</div>;
+  }
+
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.messageId}>{post.content}</li>
+      ))}
+    </ul>
+  );
 }
 ```
 
-The hook returns null while the results are loading asynchronously, or if the starting fact is null.
+## Basic Usage
 
-## Mappings
+Use the useSpecification hook to bind a Jinaga specification to your component. This hook keeps your UI in sync with the current facts, including offline updates and real-time changes.
 
-Once you have a specification, you can map it to a React component.
-Do this by calling the `mapProps` function with the specification, and then the `to` function with the component.
-Function components or class components are accepted.
-If the component takes additional properties, you can use the generic argument on `to` to declare them (TypeScript only).
+```javascript
+import { useSpecification } from 'jinaga-react';
+import { j, Post, postList } from './model';
 
-```typescript
-interface MessageProps {
-    onReply(): void;
+export function PostList() {
+  const { data: posts, loading } = useSpecification(j, postList, {});
+
+  if (posts === null) {
+    return null; // Initial transient state: render nothing
+  }
+
+  if (loading) {
+    return <div>Loading posts...</div>;
+  }
+
+  if (posts.length === 0) {
+    return <div>No posts found.</div>;
+  }
+
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.messageId}>{post.content}</li>
+      ))}
+    </ul>
+  );
 }
-
-const messageMapping = mapProps(messageSpec).to<MessageProps>(({ text, sender, onReply }) => (
-    <>
-        <p className="message-text">{text}</p>
-        <p className="message-sender">{sender}</p>
-        <button onClick={onReply}>Reply</button>
-    </>
-));
 ```
 
-Or if you prefer a class component rather than a function component, pass the constructor.
+Behavior summary:
+- data === null: Transient startup — show nothing to avoid flashes.
+- loading === true: A network round-trip is underway.
+- data.length === 0: No matching facts.
+- Otherwise: Render the facts.
+
+## Parameters
+
+You can pass parameters to a specification. If you pass objects, be sure they are stable across renders (using useMemo) to avoid unnecessary resubscriptions.
 
 ```javascript
-class MessagePresenter extends React.Component {
-    constructor(props) {
-        super(props);
-    }
+import { useMemo } from 'react';
+import { useSpecification } from 'jinaga-react';
+import { j, postsByAuthor } from './model';
 
-    render() {
-        return (
-            <>
-                <p className="message-text">{this.props.text}</p>
-                <p className="message-sender">{this.props.sender}</p>
-                <button onClick={this.props.onReply}>Reply</button>
-            </>
-        );
-    }
+export function AuthorPosts({ author }) {
+  const parameters = useMemo(() => ({ author }), [author]);
+  const { data: posts } = useSpecification(j, postsByAuthor, parameters);
+
+  if (posts === null) {
+    return null;
+  }
+
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.messageId}>{post.content}</li>
+      ))}
+    </ul>
+  );
 }
-
-const messageMapping = mapProps(messageSpec).to(MessagePresenter);
 ```
 
-## Containers
+## Full API
 
-Now that you've mapped the specified properties into a component, you can wrap that component in a container.
-Define a container component with the `jiangaContainer` function.
-Pass in the Jinaga instance (typically called `j`) and the mapping.
+useSpecification(jinaga, specification, parameters?)
+
+The useSpecification hook returns an object with these properties:
+
+| Property    | Type                  | Meaning                                                                 |
+|-------------|-----------------------|-------------------------------------------------------------------------|
+| data        | TProjection[] | null | The facts matching your specification. null during transient startup.   |
+| loading     | boolean               | true when a network round-trip is underway and data is missing locally. |
+| error       | Error | null          | If an error occurs during the loaded() promise, it appears here.        |
+| clearError  | () => void            | A function you can call to clear the current error manually.            |
+
+## Handling Edge Cases
+
+1. Blank State on Startup
+
+During the very first render, data will be null, even if loading is false.
+This startup phase is extremely short. You should render nothing during this phase to avoid distracting flashes.
 
 ```javascript
-const MessageView = jinagaContainer(j, messageMapping);
-```
-
-You can now use this container component as a regular React component.
-It has a prop called `fact` that takes the starting point of the graph.
-It also takes any unbound props that were added in the call to `mapProps`.`to`.
-
-```javascript
-const message = new Message("Twas Brillig", user, new Channel("General"), new Date());
-
-function onReply() {
-    // ...
+if (data === null) {
+  return null;
 }
-
-ReactDOM.render(
-    <MessageView fact={message} onReply={onReply} />,
-    document.getElementById("message-host"));
 ```
 
-## Collections
+2. Loading Spinner
 
-Of course, it doesn't make much sense to have a page that displays just one message.
-You want a list of messages in a channel.
-You can compose mappings into other specifications using the `collection` function.
+If loading is true, it means the app expects a network fetch.
+You may want to show a spinner only if this network delay becomes noticeable.
 
 ```javascript
-const channelSpec = specificationFor(Channel, {
-    identifier: field(c => c.identifier),
-    Messages: collection(j.for(Message.inChannel), messageMapping, descending(m => m.sentAt))
+if (loading) {
+  return <Spinner />;
+}
+```
+
+Note: Cached data will still be shown immediately if available — the user doesn’t have to wait.
+
+3. Handling Errors
+
+In rare cases (such as replicator misconfiguration), you might encounter an error.
+
+```javascript
+const { data, loading, error, clearError } = useSpecification(j, someSpec, {});
+
+if (error) {
+  return (
+    <div>
+      Error: {error.message}
+      <button onClick={clearError}>Dismiss</button>
+    </div>
+  );
+}
+```
+
+Normally, applications can ignore error handling unless you’re debugging deep network issues.
+
+## Migration Notes
+
+Earlier versions of Jinaga-React used Mappings and Containers.
+Those have been deprecated.
+The current best practice is to use useSpecification exclusively for binding data into components.
+
+## Example: Complex Component
+
+```javascript
+import { useSpecification } from 'jinaga-react';
+import { j, Company, employeesOfCompany } from './model';
+
+export function EmployeeList({ company }: { company: Company }) {
+  const parameters = useMemo(() => ({ company }), [company]);
+  const { data: employees, loading, error, clearError } = useSpecification(j, employeesOfCompany, parameters);
+
+  if (employees === null) {
+    return null;
+  }
+
+  if (error) {
+    return (
+      <div>
+        Error loading employees: {error.message}
+        <button onClick={clearError}>Retry</button>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return <div>Loading employees...</div>;
+  }
+
+  if (employees.length === 0) {
+    return <div>No employees found.</div>;
+  }
+
+  return (
+    <ul>
+      {employees.map(employee => (
+        <li key={employee.employeeId}>{employee.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+## Summary
+
+Jinaga-React lets you build React apps that are:
+- Offline-first: Local cache is primary.
+- Live-updating: UI refreshes automatically as facts change.
+- Declarative: You describe what you want, not how to load it.
+
+Use useSpecification to make building reactive applications simple, clean, and powerful.
+
+## Example Project Structure
+
+Here’s a simple way to organize a Jinaga-React application:
+
+```
+src/
+├── jinaga.ts           # Create and export your Jinaga instance
+├── model/
+│   ├── post.ts         # Define facts and specifications for Posts
+│   └── user.ts         # (Optional) Define facts for Users
+├── components/
+│   ├── PostList.tsx    # React component using useSpecification
+│   └── AuthorPosts.tsx # Another example component
+├── App.tsx             # Main app layout
+└── index.tsx           # React entry point
+```
+
+Key ideas:
+- jinaga.ts: Your single source of the configured j instance.
+- model/: Fact types and specifications organized by domain concepts.
+- components/: React components, each connecting to specifications as needed.
+- App.tsx: High-level routing, layouts, authentication, etc.
+
+## Example jinaga.ts
+
+```javascript
+import { JinagaBrowser } from 'jinaga-browser';
+
+export const j = new JinagaBrowser({
+  httpEndpoint: "https://your-replicator.example.com/"
 });
 ```
 
-I gave the `Messages` prop a capitalized name.
-Want to know why?
-Because that lets me use it as a component!
-Supply any unbound parameters.
+## Example model/post.ts
 
 ```javascript
-const channelMapping = channelSpec(( { identifier, Messages }) => (
-    <>
-        <h1>{identifier}</h1>
-        <Messages onReply={onReply} />
-    </>
-));
+import { predefine } from 'jinaga';
+
+export class Post {
+  type = "Post" as const;
+  constructor(
+    public messageId: string,
+    public content: string
+  ) {}
+}
+
+export const postList = predefine(Post, j => j
+  .match()
+  .select()
+  .orderBy(p => p.messageId)
+);
 ```
 
-The collection component will render all of the results of the template function using the child mapping, and in the specified order.
+## Example components/PostList.tsx
 
-There are loads of ways to compose specifications and mappings.
-The field specification functions include:
+```javascript
+import { useSpecification } from 'jinaga-react';
+import { j, postList } from '../model/post';
 
-| Function | Purpose | Example |
-| -- | -- | -- |
-| field | Pluck one field from the fact. Also used to fetch the fact itself. | `text: field(m => m.text)` |
-| projection | Map a single child component. | `UserView: projection(userViewMapping)` |
-| collection | Map a collection of child components. | `Messages: collection(j.for(messagesInChannel), messageMapping)` |
-| property | Match a single value of a mutable property. | `name: property(j.for(nameOfUser), n => n.value, "<user>")` |
-| mutable | Match all candidate values of a mutable property. | `name: mutable(j.for(nameOfUser), userNames => userNames.map(n => n.value).join(", "))` |
-| array | Construct an array of child objects. | `messages: array(j.for(messagesInChannel), { text: field(m => m.text) })` |
+export function PostList() {
+  const { data: posts, loading } = useSpecification(j, postList, {});
+
+  if (posts === null) {
+    return null;
+  }
+
+  if (loading) {
+    return <div>Loading posts...</div>;
+  }
+
+  return (
+    <ul>
+      {posts.map(post => (
+        <li key={post.messageId}>{post.content}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+This setup keeps your application modular, easy to extend, and closely aligned with Jinaga’s offline-first design.


### PR DESCRIPTION
Update `README.md` with new full README draft, including Getting Started and Example Project Structure sections.

* **New Full README Draft**
  - Replace the entire content with the new full README draft.
  - Add the "Getting Started" section before the "Basic Usage" section.
  - Add the "Example Project Structure" section after the "Getting Started" section.
  - Remove references to deprecated Mappings and Containers.
  - Include new usage examples for `useSpecification`.
  - Include new API details for `useSpecification`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jinaga/jinaga-react/pull/17?shareId=83967d10-d0d9-4948-b463-eeef1c8e8bcc).