### PR TITLE
Add useSubscription hook with live replicator updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,37 @@ The `useSpecification` hook returns an object with these properties:
 | `error`      | `Error \| null`         | If an error occurs while loading, it appears here.                        |
 | `clearError` | `() => void`            | A function you can call to clear the current error manually.              |
 
+### `useSubscription(jinaga, specification, parameters)`
+
+`useSubscription` has the **same signature and return shape** as `useSpecification`. The
+difference is in how it stays up to date:
+
+- `useSpecification` uses `jinaga.watch`. It loads matching facts once and then reacts to
+  changes in the **local** store. It does not hold a connection open.
+- `useSubscription` uses `jinaga.subscribe`. It opens a **persistent streaming connection**
+  to the replicator so that matching facts are **pushed in real time** as other clients
+  create them.
+
+Use `useSubscription` when you need live updates from the server (for example, a feed that
+multiple users edit concurrently). Use `useSpecification` when local reactivity is enough.
+
+#### ⚠️ Serve the replicator over HTTP/2
+
+Each subscription holds one streaming HTTP connection open **per distinct feed** produced by
+the specification, and a single specification can fan out to several feeds. Jinaga
+reference-counts feeds, so identical subscriptions share a connection — the cost is the
+number of *distinct* feeds across all live subscriptions, not the number of hooks.
+
+Browsers cap concurrent connections to a single origin at **~6 over HTTP/1.1**. Because the
+held-open feed streams also compete with the `load` requests that fetch the underlying
+facts, exhausting that pool can stall — or in the worst case deadlock — your app.
+
+**Serve the Jinaga replicator over HTTP/2 (or HTTP/3) in production.** HTTP/2 multiplexes all
+streams over a single connection (~100 concurrent streams), which removes the per-origin
+connection limit as a practical concern. Any modern reverse proxy, CDN, or managed host
+negotiates HTTP/2 by default. If you can only serve HTTP/1.1, prefer `useSpecification` and
+keep the number of concurrent `useSubscription` hooks small.
+
 ## Handling Edge Cases
 
 ### 1. **Blank State on Startup**

--- a/src/hooks/useSpecification.ts
+++ b/src/hooks/useSpecification.ts
@@ -6,6 +6,10 @@ export type ProjectionOf<TSpecification> = TSpecification extends SpecificationO
 type CacheState = 'uninitialized' | 'loading' | 'ready';
 type NullableElements<TGiven extends unknown[]> = TGiven extends [infer First, ...infer Rest] ? [First | null, ...NullableElements<Rest>] : TGiven;
 
+// The Observer handle returned by both j.watch and j.subscribe. Derived from the
+// public Jinaga API rather than a deep import so it stays valid as jinaga evolves.
+type ObserverHandle = ReturnType<Jinaga['watch']>;
+
 export interface SpecificationResult<TProjection> {
   loading: boolean;
   data: TProjection[] | null;
@@ -25,45 +29,13 @@ export function useSpecification<TGiven extends unknown[], TProjection>(j: Jinag
       return;
 
     const nonNullGiven = given as TGiven;
-    const watch = j.watch(specification, ...nonNullGiven, (projection: MakeObservable<TProjection>) => {
-      const element = removeObservables(projection);
-      const elementKey = computeElementKey(element);
-      setProjections(list => [...list, element]);
-
-      const setChildProjections = <TKey extends keyof TProjection>(key: TKey, updater: (childList: TProjection[TKey]) => TProjection[TKey]) => {
-        setProjections((list) => list.map((p) => {
-          if (computeElementKey(p) === elementKey) {
-            return {
-              ...p,
-              [key]: updater(p[key])
-            };
-          } else {
-            return p;
-          }
-        }));
-      };
-      watchObservables(projection, setChildProjections);
-
-      return (): void => {
-        setProjections(list => list.filter(p => computeElementKey(p) !== elementKey));
-      };
-    });
-    watch.cached()
-      .then(cacheReady => {
-        if (cacheReady) {
-          setState('ready');
-        } else {
-          setState('loading');
-          watch.loaded()
-            .catch(e => setError(e))
-            .finally(() => setState('ready'));
-        }
-      });
+    const observer = j.watch(specification, ...nonNullGiven, createOnAdded<TProjection>(setProjections));
+    manageState(observer, setState, setError);
     return () => {
       setState('uninitialized');
       setProjections([]);
       setError(null);
-      watch.stop();
+      observer.stop();
     };
   }, [...factHashes(given), specification, setProjections, setState, setError]);
 
@@ -71,6 +43,88 @@ export function useSpecification<TGiven extends unknown[], TProjection>(j: Jinag
   const loading = state === 'loading';
   const data = (state === 'ready' && !error) ? projections : null;
   return { loading, data, error, clearError };
+}
+
+/**
+ * Like {@link useSpecification}, but uses `j.subscribe` instead of `j.watch` so that
+ * matching facts are pushed from the replicator in real time.
+ *
+ * Connection note: each subscription holds one persistent streaming HTTP connection
+ * open per distinct feed produced by the specification (a single specification can fan
+ * out to several feeds). Identical feeds are shared and reference-counted by jinaga, so
+ * the cost is the number of distinct feeds across all live subscriptions, not the number
+ * of hooks. Because browsers cap concurrent connections per origin at ~6 over HTTP/1.1 —
+ * and those held-open streams can starve the `load` requests that fetch the underlying
+ * facts — the replicator SHOULD be served over HTTP/2 (or HTTP/3) in production, where
+ * streams are multiplexed over a single connection (~100 concurrent streams). See the
+ * README for details.
+ */
+export function useSubscription<TGiven extends unknown[], TProjection>(j: Jinaga, specification: SpecificationOf<TGiven, TProjection>, ...given: NullableElements<TGiven>): SpecificationResult<TProjection> {
+
+  const [projections, setProjections] = React.useState<TProjection[]>([]);
+  const [state, setState] = React.useState<CacheState>('uninitialized');
+  const [error, setError] = React.useState<Error | null>(null);
+
+  React.useEffect(() => {
+    // Wait until all givens are specified.
+    if (given.some(g => g === null))
+      return;
+
+    const nonNullGiven = given as TGiven;
+    const observer = j.subscribe(specification, ...nonNullGiven, createOnAdded<TProjection>(setProjections));
+    manageState(observer, setState, setError);
+    return () => {
+      setState('uninitialized');
+      setProjections([]);
+      setError(null);
+      observer.stop();
+    };
+  }, [...factHashes(given), specification, setProjections, setState, setError]);
+
+  const clearError = React.useCallback(() => setError(null), [setError]);
+  const loading = state === 'loading';
+  const data = (state === 'ready' && !error) ? projections : null;
+  return { loading, data, error, clearError };
+}
+
+function createOnAdded<TProjection>(setProjections: React.Dispatch<React.SetStateAction<TProjection[]>>) {
+  return (projection: MakeObservable<TProjection>) => {
+    const element = removeObservables(projection);
+    const elementKey = computeElementKey(element);
+    setProjections(list => [...list, element]);
+
+    const setChildProjections = <TKey extends keyof TProjection>(key: TKey, updater: (childList: TProjection[TKey]) => TProjection[TKey]) => {
+      setProjections((list) => list.map((p) => {
+        if (computeElementKey(p) === elementKey) {
+          return {
+            ...p,
+            [key]: updater(p[key])
+          };
+        } else {
+          return p;
+        }
+      }));
+    };
+    watchObservables(projection, setChildProjections);
+
+    return (): void => {
+      setProjections(list => list.filter(p => computeElementKey(p) !== elementKey));
+    };
+  };
+}
+
+function manageState(observer: ObserverHandle, setState: React.Dispatch<React.SetStateAction<CacheState>>, setError: React.Dispatch<React.SetStateAction<Error | null>>) {
+  observer.cached()
+    .then(cacheReady => {
+      if (cacheReady) {
+        setState('ready');
+      } else {
+        setState('loading');
+        observer.loaded()
+          .catch(e => setError(e))
+          .finally(() => setState('ready'));
+      }
+    });
 }
 
 function factHashes(facts: any[]): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { ProjectionOf, SpecificationResult, useSpecification } from "./hooks/useSpecification";
+export { ProjectionOf, SpecificationResult, useSpecification, useSubscription } from "./hooks/useSpecification";

--- a/test/hooks/useSubscription.spec.ts
+++ b/test/hooks/useSubscription.spec.ts
@@ -1,0 +1,117 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { JinagaTest } from "jinaga";
+import { useSubscription } from "../../src";
+import { Item, ItemDeleted, ItemDescription, Root, model } from "../model";
+
+const itemsInRoot = model.given(Root).match((root, facts) =>
+  facts.ofType(Item)
+    .join(item => item.root, root)
+    .notExists(item => facts.ofType(ItemDeleted)
+      .join(deleted => deleted.item, item)
+    )
+);
+
+const descriptionsOfItem = model.given(Item).match((item, facts) =>
+  facts.ofType(ItemDescription)
+    .join(description => description.item, item)
+    .notExists(description => facts.ofType(ItemDescription)
+      .join(next => next.prior, description)
+    )
+);
+
+describe("useSubscription", () => {
+  it("should return an empty list", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+
+    const { result } = renderHook(() => useSubscription(j, itemsInRoot, root));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("should return one item", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+    const item = await j.fact(new Item(root, new Date()));
+
+    const { result } = renderHook(() => useSubscription(j, itemsInRoot, root));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([item]));
+  });
+
+  it("should add an item", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+
+    const { result } = renderHook(() => useSubscription(j, itemsInRoot, root));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+
+    const item = await j.fact(new Item(root, new Date()));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([item]));
+  });
+
+  it("should remove an item", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+    const item = await j.fact(new Item(root, new Date()));
+
+    const { result } = renderHook(() => useSubscription(j, itemsInRoot, root));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+
+    await j.fact(new ItemDeleted(item));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("should update on edit", async () => {
+    const j = JinagaTest.create({});
+    const root = await j.fact(new Root("root-identifier"));
+    const item = await j.fact(new Item(root, new Date()));
+    const description = await j.fact(new ItemDescription(item, "description", []));
+
+    const { result } = renderHook(() => useSubscription(j, descriptionsOfItem, item));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([description]));
+
+    const replacement = await j.fact(new ItemDescription(item, "description", [description]));
+    await waitFor(() => {
+      expect(result.current.data).toBeTruthy();
+    });
+    expect(result.current.loading).toBeFalsy();
+    expect(result.current.error).toBeNull();
+    expect(roundTrip(result.current.data)).toEqual(roundTrip([replacement]));
+  });
+});
+
+function roundTrip<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj));
+}


### PR DESCRIPTION
Revive the useSubscription feature (PR #13) on top of current main.
The hook mirrors useSpecification but uses j.subscribe instead of
j.watch, so matching facts are pushed from the replicator in real time.

Factor the shared projection wiring (createOnAdded) and cache-state
handling (manageState) out of useSpecification so both hooks reuse them.
The Observer handle type is derived from the public Jinaga API
(ReturnType<Jinaga['watch']>) rather than a deep import.

Document the HTTP/2 requirement in the README: each subscription holds
one persistent streaming connection per distinct feed, which can exhaust
the browser's ~6-connection HTTP/1.1 limit, so the replicator should be
served over HTTP/2 in production.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HfQX9rqK7LLpticfVczcNJ