### PR TITLE
Surface distribution authorization state in useSpecification

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ export function PostList({ site }: { site: Site }) {
 **Behavior summary:**
 - `data === null`: Transient startup — show nothing to avoid flashes.
 - `loading === true`: A network round-trip is underway.
+- `distributionPending === true`: A distribution rule hasn't authorized you yet, but it may self-heal when an authorizing fact arrives — show a "waiting for access" state, not an error.
+- `error !== null`: Something needs attention (including a distribution denial that won't self-heal, such as a missing rule or `not-authenticated`).
 - `data.length === 0`: No matching facts.
 - Otherwise: Render the facts.
 
@@ -62,12 +64,19 @@ export function PostList({ site }: { site: Site }) {
 
 The `useSpecification` hook returns an object with these properties:
 
-| Property     | Type                    | Meaning                                                                   |
-| :----------- | :---------------------- | :------------------------------------------------------------------------ |
-| `data`       | `TProjection[] \| null` | The facts matching your specification. `null` during transient startup.   |
-| `loading`    | `boolean`               | `true` when a network round-trip is underway and data is missing locally. |
-| `error`      | `Error \| null`         | If an error occurs while loading, it appears here.                        |
-| `clearError` | `() => void`            | A function you can call to clear the current error manually.              |
+| Property                 | Type                             | Meaning                                                                   |
+| :----------------------- | :------------------------------- | :------------------------------------------------------------------------ |
+| `data`                   | `TProjection[] \| null`          | The facts matching your specification. `null` during transient startup.   |
+| `loading`                | `boolean`                        | `true` when a network round-trip is underway and data is missing locally. |
+| `error`                  | `Error \| null`                  | If an error occurs while loading, it appears here. A non-self-healing distribution denial surfaces as a `DistributionDeniedError`. |
+| `distributionPending`    | `boolean`                        | `true` when distribution hasn't authorized you yet but the result will self-heal once an authorizing fact arrives (a `reactive` decision, or a `principal-excluded` denial). Distinct from `loading`; never `true` at the same time as `error`. |
+| `distributionDiagnostic` | `DistributionDiagnostic \| null` | The decision behind `distributionPending`/`error`; `null` when authorized. Read `.code` to branch (e.g. trigger login on `not-authenticated`). |
+| `clearError`             | `() => void`                     | A function you can call to clear the current error manually.              |
+
+**Distribution states.** When a specification is covered by a `share ... with ...` distribution rule, the replicator reports whether you're authorized. `useSpecification` reduces that to one signal per branch you render:
+
+- **`reactive`** or **`principal-excluded`** → `distributionPending`. You're not authorized *yet*, but access is granted by a fact that can still replicate in (often via a `j.subscribe` you run alongside the watch). Show a "waiting for access" state; it clears when the first result arrives.
+- **`no-matching-rule`**, **`spec-more-restrictive-than-rule`**, or **`not-authenticated`** → `error` (a `DistributionDeniedError`). These don't self-heal on their own: the first two are authoring mistakes, and `not-authenticated` needs new tokens or a login. Branch on `distributionDiagnostic.code` to react (e.g. route to login).
 
 ## Handling Edge Cases
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react-dom": "^19.0.4",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
-        "jinaga": "^6.9.0",
+        "jinaga": "^6.11.1",
         "nodemon": "^3.1.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -24,7 +24,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "jinaga": "^6.8.1",
+        "jinaga": "^6.11.1",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0",
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0"
       }
@@ -3815,9 +3815,9 @@
       }
     },
     "node_modules/jinaga": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.9.0.tgz",
-      "integrity": "sha512-05zPOOoSTRuY3JtGMIli1lVY+/BPSb3vOAgwOGyMNjYqbt9J+ZCaMK3yhTIyi6h1vJTgsUeYvPHyYTwbPWYOVA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/jinaga/-/jinaga-6.11.1.tgz",
+      "integrity": "sha512-frkq+ksi+BkWhqly6yyKZKlud8CQ1aNFOe0kUH/uVbf4RYzXWfb2Njs4HjW9Bqb1MKvRYSxenRoUQHQ3zUrPFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/react-dom": "^19.0.4",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "jinaga": "^6.9.0",
+    "jinaga": "^6.11.1",
     "nodemon": "^3.1.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -39,7 +39,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "jinaga": "^6.8.1",
+    "jinaga": "^6.11.1",
     "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0",
     "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0"
   }

--- a/src/hooks/useSpecification.ts
+++ b/src/hooks/useSpecification.ts
@@ -1,4 +1,4 @@
-import { Jinaga, MakeObservable, SpecificationOf, computeObjectHash } from 'jinaga';
+import { DistributionDeniedError, DistributionDiagnostic, Jinaga, MakeObservable, SpecificationOf, computeObjectHash } from 'jinaga';
 import { hashSymbol } from 'jinaga/dist/fact/hydrate';
 import * as React from 'react';
 
@@ -10,6 +10,24 @@ export interface SpecificationResult<TProjection> {
   loading: boolean;
   data: TProjection[] | null;
   error: Error | null;
+  /**
+   * True when the specification is denied by distribution for a reason that
+   * self-heals when an authorizing fact arrives (issue #179): a `reactive`
+   * decision (the subscription race), or a `principal-excluded` denial (the
+   * user is authenticated but not yet in the authorized set — access is granted
+   * by a fact that can still replicate in). Render this as a "waiting for
+   * access" state, distinct from `loading`. It clears when the first result
+   * arrives. It is never true at the same time as `error`.
+   */
+  distributionPending: boolean;
+  /**
+   * The single most-significant distribution decision behind `distributionPending`
+   * or an `error` of type `DistributionDeniedError`; `null` when the feed is
+   * authorized. An error-class decision outranks a pending one. Read
+   * `distributionDiagnostic.code` to branch (e.g. trigger login on
+   * `not-authenticated`).
+   */
+  distributionDiagnostic: DistributionDiagnostic | null;
   clearError: () => void;
 }
 
@@ -18,6 +36,7 @@ export function useSpecification<TGiven extends unknown[], TProjection>(j: Jinag
   const [projections, setProjections] = React.useState<TProjection[]>([]);
   const [state, setState] = React.useState<CacheState>('uninitialized');
   const [error, setError] = React.useState<Error | null>(null);
+  const [distributionDiagnostic, setDistributionDiagnostic] = React.useState<DistributionDiagnostic | null>(null);
 
   React.useEffect(() => {
     // Wait until all givens are specified.
@@ -26,8 +45,38 @@ export function useSpecification<TGiven extends unknown[], TProjection>(j: Jinag
 
     let active = true;
 
+    // Reduce the per-feed distribution decisions the observer captures to a
+    // single, intention-revealing signal (issue #179). A non-self-healing
+    // denial sets `error`; a self-healing one sets `distributionPending`.
+    // Error outranks pending so a real misconfiguration or a required login is
+    // never masked by a pending sibling feed.
+    const captured: DistributionDiagnostic[] = [];
+    let firstResultArrived = false;
+
+    const recomputeDistribution = () => {
+      if (!active) return;
+      const errorDiagnostic = captured.find(isDistributionError);
+      if (errorDiagnostic) {
+        setError(new DistributionDeniedError([errorDiagnostic]));
+        setDistributionDiagnostic(errorDiagnostic);
+        return;
+      }
+      // A watch has no clearing event (only subscribe does), so a pending feed
+      // clears the practical way: once the first result arrives — the
+      // authorizing fact reached the local store (e.g. via a sibling subscribe)
+      // and the inverse listeners delivered a row.
+      const pendingDiagnostic = firstResultArrived
+        ? undefined
+        : captured.find(isDistributionPending);
+      setDistributionDiagnostic(pendingDiagnostic ?? null);
+    };
+
     const nonNullGiven = given as TGiven;
     const watch = j.watch(specification, ...nonNullGiven, (projection: MakeObservable<TProjection>) => {
+      if (!firstResultArrived) {
+        firstResultArrived = true;
+        recomputeDistribution();
+      }
       const element = removeObservables(projection);
       const elementKey = computeElementKey(element);
       setProjections(list => insertSorted(list, element, computeElementKey, elementKey));
@@ -50,6 +99,13 @@ export function useSpecification<TGiven extends unknown[], TProjection>(j: Jinag
         setProjections(list => list.filter(p => computeElementKey(p) !== elementKey));
       };
     });
+    // Register before the fetch settles so no decision is missed; any
+    // diagnostics already captured are replayed to this handler on registration.
+    watch.onDiagnostic(diagnostic => {
+      captured.push(diagnostic);
+      recomputeDistribution();
+    });
+
     watch.cached()
       .then(cacheReady => {
         if (!active) return;
@@ -67,14 +123,37 @@ export function useSpecification<TGiven extends unknown[], TProjection>(j: Jinag
       setState('uninitialized');
       setProjections([]);
       setError(null);
+      setDistributionDiagnostic(null);
       watch.stop();
     };
-  }, [...factHashes(given), specification, setProjections, setState, setError]);
+  }, [...factHashes(given), specification, setProjections, setState, setError, setDistributionDiagnostic]);
 
   const clearError = React.useCallback(() => setError(null), [setError]);
   const loading = state === 'loading';
   const data = (state === 'ready' && !error) ? projections : null;
-  return { loading, data, error, clearError };
+  const distributionPending = distributionDiagnostic !== null && isDistributionPending(distributionDiagnostic);
+  return { loading, data, error, distributionPending, distributionDiagnostic, clearError };
+}
+
+// A distribution decision self-heals — render it as `distributionPending`, not
+// an error — when it is `reactive` (the subscription race), or a
+// `principal-excluded` denial: the user is authenticated but not yet in the
+// authorized set, and access is granted by a fact that can still replicate in.
+function isDistributionPending(diagnostic: DistributionDiagnostic): boolean {
+  if (diagnostic.cleared) return false;
+  if (diagnostic.reactive) return true;
+  return diagnostic.code === 'principal-excluded';
+}
+
+// A distribution decision needs intervention — render it as `error` — when it
+// is a structural denial (a missing or narrowed-past rule) that never
+// self-heals, or `not-authenticated`, which is not healed by a fact arriving
+// but by acquiring new tokens or routing the user through login.
+function isDistributionError(diagnostic: DistributionDiagnostic): boolean {
+  if (diagnostic.cleared || diagnostic.reactive) return false;
+  return diagnostic.code === 'no-matching-rule'
+    || diagnostic.code === 'spec-more-restrictive-than-rule'
+    || diagnostic.code === 'not-authenticated';
 }
 
 function factHashes(facts: any[]): string[] {

--- a/src/hooks/useSpecification.ts
+++ b/src/hooks/useSpecification.ts
@@ -131,7 +131,9 @@ export function useSpecification<TGiven extends unknown[], TProjection>(j: Jinag
   const clearError = React.useCallback(() => setError(null), [setError]);
   const loading = state === 'loading';
   const data = (state === 'ready' && !error) ? projections : null;
-  const distributionPending = distributionDiagnostic !== null && isDistributionPending(distributionDiagnostic);
+  // Error outranks pending, including a non-distribution error surfaced by
+  // watch.loaded() — so `distributionPending` and `error` are never both set.
+  const distributionPending = !error && distributionDiagnostic !== null && isDistributionPending(distributionDiagnostic);
   return { loading, data, error, distributionPending, distributionDiagnostic, clearError };
 }
 

--- a/test/hooks/useSpecificationDistribution.spec.ts
+++ b/test/hooks/useSpecificationDistribution.spec.ts
@@ -13,7 +13,7 @@ import {
   PassThroughFork,
   Specification,
 } from "jinaga";
-import { Network } from "jinaga/dist/managers/NetworkManager";
+import type { Network } from "jinaga";
 import { useSpecification } from "../../src";
 import { Item, Root, model } from "../model";
 

--- a/test/hooks/useSpecificationDistribution.spec.ts
+++ b/test/hooks/useSpecificationDistribution.spec.ts
@@ -1,0 +1,161 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  AuthenticationNoOp,
+  DistributionDeniedError,
+  FactEnvelope,
+  FactManager,
+  FactReference,
+  FeedResponse,
+  FeedsResponse,
+  Jinaga,
+  MemoryStore,
+  ObservableSource,
+  PassThroughFork,
+  Specification,
+} from "jinaga";
+import { Network } from "jinaga/dist/managers/NetworkManager";
+import { useSpecification } from "../../src";
+import { Item, Root, model } from "../model";
+
+const itemsInRoot = model.given(Root).match((root, facts) =>
+  facts.ofType(Item).join(item => item.root, root)
+);
+
+// A Network double that reports caller-configured feed hashes and per-feed
+// distribution decisions, exactly as a replicator's POST /feeds does (issue
+// #207). JinagaTest's in-process NetworkDistribution throws on denial and never
+// surfaces decisions, so a real replicator response has to be simulated here.
+class DecisionNetwork implements Network {
+  public response: FeedsResponse = { feeds: [] };
+
+  feeds(_start: FactReference[], _specification: Specification): Promise<FeedsResponse> {
+    return Promise.resolve(this.response);
+  }
+
+  fetchFeed(_feed: string, bookmark: string): Promise<FeedResponse> {
+    return Promise.resolve({ references: [], bookmark });
+  }
+
+  streamFeed(
+    _feed: string,
+    bookmark: string,
+    onResponse: (factReferences: FactReference[], nextBookmark: string) => Promise<void>,
+    _onError: (err: Error) => void,
+    _feedRefreshIntervalSeconds: number
+  ): () => void {
+    Promise.resolve().then(() => onResponse([], bookmark));
+    return () => {};
+  }
+
+  load(_factReferences: FactReference[]): Promise<FactEnvelope[]> {
+    return Promise.resolve([]);
+  }
+
+  intersectForSubscribe(start: FactReference[], specification: Specification) {
+    return Promise.resolve([{ start, specification }]);
+  }
+}
+
+function makeJinaga(network: Network): Jinaga {
+  const store = new MemoryStore();
+  const factManager = new FactManager(new PassThroughFork(store), new ObservableSource(store), store, network, []);
+  return new Jinaga(new AuthenticationNoOp(), factManager, null);
+}
+
+const root = new Root("root-identifier");
+
+describe("useSpecification distribution signals (issue #179)", () => {
+  it("is quiet for an authorized feed — no pending, no error", async () => {
+    const network = new DecisionNetwork();
+    network.response = { feeds: ["f"], decisions: [{ feed: "f", decision: "authorized", reason: "" }] };
+    const j = makeJinaga(network);
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.distributionPending).toBe(false);
+    expect(result.current.distributionDiagnostic).toBeNull();
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("sets distributionPending (not error) for a reactive decision", async () => {
+    const network = new DecisionNetwork();
+    network.response = { feeds: ["f"], decisions: [{ feed: "f", decision: "reactive", reason: "pending authorization" }] };
+    const j = makeJinaga(network);
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => expect(result.current.distributionPending).toBe(true));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.distributionDiagnostic?.decision).toBe("reactive");
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("sets distributionPending (not error) for a principal-excluded denial", async () => {
+    const network = new DecisionNetwork();
+    network.response = { feeds: [], decisions: [{ feed: "f", decision: "denied", code: "principal-excluded", reason: "excluded" }] };
+    const j = makeJinaga(network);
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => expect(result.current.distributionPending).toBe(true));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.distributionDiagnostic?.code).toBe("principal-excluded");
+  });
+
+  it.each([
+    ["no-matching-rule"],
+    ["spec-more-restrictive-than-rule"],
+    ["not-authenticated"],
+  ] as const)("sets error (not pending) for a %s denial", async (code) => {
+    const network = new DecisionNetwork();
+    network.response = { feeds: [], decisions: [{ feed: "f", decision: "denied", code, reason: `denied: ${code}` }] };
+    const j = makeJinaga(network);
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    expect(result.current.error).toBeInstanceOf(DistributionDeniedError);
+    expect(result.current.distributionPending).toBe(false);
+    expect(result.current.distributionDiagnostic?.code).toBe(code);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("lets an error-class denial outrank a pending sibling feed", async () => {
+    const network = new DecisionNetwork();
+    network.response = {
+      feeds: [],
+      decisions: [
+        { feed: "pending", decision: "denied", code: "principal-excluded", reason: "excluded" },
+        { feed: "broken", decision: "denied", code: "no-matching-rule", reason: "no rule" },
+      ],
+    };
+    const j = makeJinaga(network);
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    expect(result.current.distributionPending).toBe(false);
+    expect(result.current.distributionDiagnostic?.code).toBe("no-matching-rule");
+  });
+
+  it("clears distributionPending when the first result arrives (the race resolves)", async () => {
+    const network = new DecisionNetwork();
+    network.response = { feeds: ["f"], decisions: [{ feed: "f", decision: "reactive", reason: "pending authorization" }] };
+    const j = makeJinaga(network);
+
+    const { result } = renderHook(() => useSpecification(j, itemsInRoot, root));
+    await waitFor(() => expect(result.current.distributionPending).toBe(true));
+
+    // The authorizing fact arrives locally (e.g. via a sibling subscribe): the
+    // watch's inverse listeners deliver a row, and pending resolves into data.
+    await act(async () => {
+      await j.fact(new Item(root, new Date(1000)));
+    });
+
+    await waitFor(() => expect(result.current.data?.length).toBe(1));
+    expect(result.current.distributionPending).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Downstream companion to [jinaga/jinaga-server#179](https://github.com/jinaga/jinaga-server/issues/179). A specification covered by a `share ... with ...` distribution rule can be denied at the replicator, but `useSpecification` previously showed an empty result with no way to distinguish **"nothing to see"** from **"not permitted (yet)"**. This teaches the hook to consume the observer's per-feed distribution decisions and reduce them to **one intention-revealing signal per branch the app renders**.

## New return fields (additive, non-breaking)

| Field | Meaning |
|---|---|
| `distributionPending: boolean` | A **self-healing** denial — the result will appear when an authorizing fact arrives. Render a "waiting for access" state, distinct from `loading`. Clears when the first result arrives. Never `true` at the same time as `error`. |
| `distributionDiagnostic: DistributionDiagnostic \| null` | The single most-significant decision behind `distributionPending`/`error`; `null` when authorized. Read `.code` to branch (e.g. trigger login on `not-authenticated`). |

## Decision → signal mapping

| Replicator decision | Signal |
|---|---|
| authorized | `data` |
| `reactive` | `distributionPending` |
| denied · `principal-excluded` | `distributionPending` |
| denied · `no-matching-rule` | `error` (`DistributionDeniedError`) |
| denied · `spec-more-restrictive-than-rule` | `error` |
| denied · `not-authenticated` | `error` |

The error/pending split is a **product** axis ("does the app need to act?"), deliberately *not* the core's structural/reactive axis ("will a fact heal it?"). `principal-excluded` self-heals (access is granted by a fact that can still replicate in — often via a sibling `subscribe`), so it's pending. `not-authenticated` needs new tokens or a login — an app action — so it's an error even though a login *could* change it.

**Error outranks pending** across feeds, so a real misconfiguration or a required login is never masked by a pending sibling feed.

## How `distributionPending` clears

`watch` doesn't emit a clearing event (only `subscribe` registers clearing listeners), so pending clears the practical way: **when the first result arrives** — the authorizing fact reached the local store (e.g. via a `j.subscribe` running alongside the watch) and the inverse listeners delivered a row. That's the lost race resolving into `data` with no error.

## Scope notes

- The onset decision is what distinguishes "nothing to see" (`authorized`, empty) from "not permitted yet". The remaining gap — a feed that becomes *authorized but genuinely empty* after the fact — can't be signaled without a replicator-pushed decision update, which is deferred to the WebSockets work (it requires the replicator to emit authorization transitions; the client holds neither the distribution rules nor, necessarily, the authorizing facts).
- Only `watch` is used here, so this is independent of the `query()` contract change in jinaga.js#228.

## Dependency

Requires the diagnostics API from **jinaga 6.11.1** (already published); dev + peer dependency bumped to `^6.11.1`.

## Tests

New `test/hooks/useSpecificationDistribution.spec.ts` drives real decisions through a mock `Network` (JinagaTest's in-process distribution throws on denial and never surfaces decisions, so a replicator response is simulated): authorized, reactive, each denial code, error-over-pending precedence, and pending-clears-on-first-result. Full suite **34 passing**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VokiTvx83cazRWw8zcDAzD

---
_Generated by [Claude Code](https://claude.ai/code/session_01VokiTvx83cazRWw8zcDAzD)_